### PR TITLE
Allow more complex elements

### DIFF
--- a/library/app/src/main/java/com/yayandroid/parallaxrecyclerview/ParallaxImageView.java
+++ b/library/app/src/main/java/com/yayandroid/parallaxrecyclerview/ParallaxImageView.java
@@ -23,7 +23,6 @@ public class ParallaxImageView extends ImageView {
     private boolean needToTranslate = true;
     private ParallaxImageListener listener;
 
-    private int rowHeight = -1;
     private int rowYPos = -1;
     private int recyclerViewHeight = -1;
     private int recyclerViewYPos = -1;
@@ -151,24 +150,24 @@ public class ParallaxImageView extends ImageView {
         if (values == null)
             return false;
 
-        this.rowHeight = values[0];
-        this.rowYPos = values[1];
-        this.recyclerViewHeight = values[2];
-        this.recyclerViewYPos = values[3];
+        this.rowYPos = values[0];
+        this.recyclerViewHeight = values[1];
+        this.recyclerViewYPos = values[2];
         return true;
     }
 
     private void calculateAndMove() {
         float distanceFromCenter = (recyclerViewYPos + recyclerViewHeight) / 2 - rowYPos;
 
-        int imageHeight = getDrawable().getIntrinsicHeight();
+        int drawableHeight = getDrawable().getIntrinsicHeight();
+        int imageViewHeight = getMeasuredHeight();
         float scale = 1;
         if (shouldCenterCrop) {
             scale = recomputeImageMatrix();
-            imageHeight *= scale;
+            drawableHeight *= scale;
         }
 
-        float difference = imageHeight - rowHeight;
+        float difference = drawableHeight - imageViewHeight;
         float move = (distanceFromCenter / recyclerViewHeight) * difference * parallaxRatio;
 
         moveTo((move / 2) - (difference / 2), scale);

--- a/library/app/src/main/java/com/yayandroid/parallaxrecyclerview/ParallaxRecyclerView.java
+++ b/library/app/src/main/java/com/yayandroid/parallaxrecyclerview/ParallaxRecyclerView.java
@@ -44,7 +44,10 @@ public class ParallaxRecyclerView extends RecyclerView {
             super.onScrolled(recyclerView, dx, dy);
 
             for (int i = 0; i < recyclerView.getChildCount(); i++) {
-                ((ParallaxViewHolder) recyclerView.getChildViewHolder(recyclerView.getChildAt(i))).animateImage();
+                ViewHolder viewHolder = recyclerView.getChildViewHolder(recyclerView.getChildAt(i));
+                if (viewHolder instanceof ParallaxViewHolder) {
+                    ((ParallaxViewHolder) viewHolder).animateImage();
+                }
             }
 
             if (scrollListener != null)

--- a/library/app/src/main/java/com/yayandroid/parallaxrecyclerview/ParallaxViewHolder.java
+++ b/library/app/src/main/java/com/yayandroid/parallaxrecyclerview/ParallaxViewHolder.java
@@ -31,7 +31,7 @@ public abstract class ParallaxViewHolder extends RecyclerView.ViewHolder impleme
             int[] recyclerPosition = new int[2];
             ((RecyclerView) itemView.getParent()).getLocationOnScreen(recyclerPosition);
 
-            return new int[]{itemView.getMeasuredHeight(), itemPosition[1], ((RecyclerView) itemView.getParent()).getMeasuredHeight(), recyclerPosition[1]};
+            return new int[]{itemPosition[1], ((RecyclerView) itemView.getParent()).getMeasuredHeight(), recyclerPosition[1]};
         }
     }
 


### PR DESCRIPTION
I have made two changes to improve the versatility of the component:

1. Included a sanity check in RecyclerView to only perform parallax animation on ViewHolders that extends ParallaxViewHolder, ignoring the rest and behaving like a standard RecyclerView to them
2. Modified ParallaxImageView to calculate the difference between available space and drawable size taking into account the ImageView height instead of the row height. This will allow to include the ParallaxImageView in cells without the need to fill the row height.

The changes does not break compatibility with previous versions but allows to use the component with different ViewHolder types in the same RecyclerView and to include complex cells with parallax images that does not necessary match parent height.